### PR TITLE
Added an event fired when peripherals are found

### DIFF
--- a/Konashi/Konashi.h
+++ b/Konashi/Konashi.h
@@ -103,6 +103,7 @@
 // Konashi Events
 #define KONASHI_EVENT_CENTRAL_MANAGER_POWERED_ON @"KonashiEventCentralManagerPoweredOn"
 
+#define KONASHI_EVENT_PERIPHERAL_FOUND @"KonashiEventPeripheralFound"
 #define KONASHI_EVENT_PERIPHERAL_NOT_FOUND @"KonashiEventPeripheralNotFound"
 
 #define KONASHI_EVENT_CONNECTED @"KonashiEventConnected"

--- a/Konashi/Konashi.m
+++ b/Konashi/Konashi.m
@@ -444,6 +444,7 @@
     KNS_LOG(@"Peripherals: %d", [peripherals count]);
     
     if ( [peripherals count] > 0 ) {
+        [[Konashi shared] postNotification:KONASHI_EVENT_PERIPHERAL_FOUND];
         if([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad){
             [self showModulePickeriPad];    //iPad
         } else {


### PR DESCRIPTION
This event helps to dismiss a progress dialog when peripherals are
found. I created a sample application using this event, [naoty/KonashiSample](https://github.com/naoty/KonashiSample).
