### PR TITLE
It marks as deprecated method using "__attribute__ ((deprecated))"

### DIFF
--- a/Konashi/Konashi/Konashi.h
+++ b/Konashi/Konashi/Konashi.h
@@ -485,7 +485,7 @@
  *  @return 指定したPIOの値。KonashiLevelHigh及びKonashiLevelLow。
  *	@warning このメソッドは非推奨です。 [Konashi digitalInputDidChangeValueHandler] 及び [Konashi digitalOutputDidChangeValueHandler] を用いて値を取得してください。
  */
-+ (KonashiLevel) digitalRead:(KonashiDigitalIOPin)pin NS_DEPRECATED(NA, NA, 5_0, 8_0);
++ (KonashiLevel) digitalRead:(KonashiDigitalIOPin)pin __attribute__ ((deprecated));
 
 /**
  *  PIOの値を取得します。
@@ -493,7 +493,7 @@
  *  @return PIOの状態。各bitにおいてHighの場合は1、Lowの場合は0がセットされている。
  *	@warning このメソッドは非推奨です。 [Konashi digitalInputDidChangeValueHandler] 及び [Konashi digitalOutputDidChangeValueHandler] を用いて値を取得してください。
  */
-+ (int) digitalReadAll NS_DEPRECATED(NA, NA, 5_0, 8_0);
++ (int) digitalReadAll __attribute__ ((deprecated));
 
 /// ---------------------------------
 /// @name Analog I/O (AIO)
@@ -507,7 +507,7 @@
  *  @return AIOの値。
  *	@warning このメソッドは非推奨です。 [Konashi analogPinDidChangeValueHandler] を用いて値の取得をしてください。
  */
-+ (int) analogRead:(KonashiAnalogIOPin)pin NS_DEPRECATED(NA, NA, 5_0, 8_0);
++ (int) analogRead:(KonashiAnalogIOPin)pin __attribute__ ((deprecated));
 
 /// ---------------------------------
 /// @name I2C
@@ -524,7 +524,7 @@
  *  @return 成功した場合はKonashiResultSuccess、何らかの原因で失敗した場合はKonashiResultFailure。
  *	@warning このメソッドは非推奨です。 [Konashi i2cWriteData:address] を用いてデータの書き込んでください。
  */
-+ (KonashiResult) i2cWrite:(int)length data:(unsigned char*)data address:(unsigned char)address NS_DEPRECATED(NA, NA, 5_0, 8_0);
++ (KonashiResult) i2cWrite:(int)length data:(unsigned char*)data address:(unsigned char)address __attribute__ ((deprecated));
 
 /**
  *  I2Cで接続されたモジュールから得られるデータを取得します。[Konashi i2cReadRequest:address:] を用いてデータの要求後に正しいデータを取得可能です。
@@ -535,7 +535,7 @@
  *  @return 値の取得に成功した場合はKonashiResultSuccess、失敗した場合はKonashiResultFailure。
  *	@warning このメソッドは非推奨です。 [Konashi i2cReadCompleteHandler] を用いてデータの取得をしてください。
  */
-+ (KonashiResult) i2cRead:(int)length data:(unsigned char*)data NS_DEPRECATED(NA, NA, 5_0, 8_0);
++ (KonashiResult) i2cRead:(int)length data:(unsigned char*)data __attribute__ ((deprecated));
 
 /// ---------------------------------
 /// @name UART
@@ -549,7 +549,7 @@
  *
  *  @return 設定に成功した場合はKonashiResultSuccess、何らかの原因で失敗した場合はKonashiResultFailure。
  */
-+ (KonashiResult) uartMode:(KonashiUartMode)mode NS_DEPRECATED(NA, NA, 5_0, 8_0);
++ (KonashiResult) uartMode:(KonashiUartMode)mode __attribute__ ((deprecated));
 
 /**
  *  UART の通信速度を設定します。
@@ -558,7 +558,7 @@
  *
  *  @return 設定に成功した場合はKonashiResultSuccess、何らかの原因で失敗した場合はKonashiResultFailure。
  */
-+ (KonashiResult) uartBaudrate:(KonashiUartBaudrate)baudrate NS_DEPRECATED(NA, NA, 5_0, 8_0);
++ (KonashiResult) uartBaudrate:(KonashiUartBaudrate)baudrate __attribute__ ((deprecated));
 
 /**
  *  UART でデータを送信します。
@@ -568,7 +568,7 @@
  *  @return 成功した場合はKonashiResultSuccess、何らかの原因で失敗した場合はKonashiResultFailure。
  *	@warning このメソッドは非推奨です。 [Konashi uartWriteData:] を用いでデータを送信してください。
  */
-+ (KonashiResult) uartWrite:(unsigned char)data NS_DEPRECATED(NA, NA, 5_0, 8_0);
++ (KonashiResult) uartWrite:(unsigned char)data __attribute__ ((deprecated));
 
 /**
  *  uartの値を取得します。
@@ -576,7 +576,7 @@
  *  @return 取得した値。
  *	@warning このメソッドは非推奨です。 [Konashi uartRxCompleteHandler] 及び [Konashi readUartData] を用いて値を取得してください。
  */
-+ (unsigned char) uartRead NS_DEPRECATED(NA, NA, 5_0, 8_0);
++ (unsigned char) uartRead __attribute__ ((deprecated));
 
 /// ---------------------------------
 /// @name Hardware Control
@@ -588,7 +588,7 @@
  *  @return バッテリーの残量(%)
  *	@warning このメソッドは非推奨です。 [Konashi batteryLevelDidUpdateHandler] を用いて残量を取得してください。
  */
-+ (int) batteryLevelRead NS_DEPRECATED(NA, NA, 5_0, 8_0);
++ (int) batteryLevelRead __attribute__ ((deprecated));
 
 /**
  *  RSSIの値を取得します。
@@ -596,6 +596,6 @@
  *  @return RSSIの値。
  *	@warning このメソッドは非推奨です。 [Konashi signalStrengthDidUpdateHandler] を用いてRSSIを取得してください。
  */
-+ (int) signalStrengthRead NS_DEPRECATED(NA, NA, 5_0, 8_0);
++ (int) signalStrengthRead __attribute__ ((deprecated));
 
 @end


### PR DESCRIPTION
非推奨であるメソッドと宣言する方法を正しいものに直しました。
サンプルプロジェクトやいくつかのカテゴリで非推奨メソッド利用しているため、ワーニングが出ることを確認しています。
