### PR TITLE
undef KONASHI_DBEUG

### DIFF
--- a/Konashi/Konashi/Constant/KonashiConstant.h
+++ b/Konashi/Konashi/Constant/KonashiConstant.h
@@ -11,7 +11,7 @@
 
 // Debug
 // Define in "Build Settings > Preprocessor Macros", not here
-#define KONASHI_DEBUG
+// #define KONASHI_DEBUG
 
 #ifdef KONASHI_DEBUG
 #define KNS_LOG(__FORMAT__, ...) NSLog((@"%s line %d $ " __FORMAT__), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__)


### PR DESCRIPTION
not define KONASHI_DBEUG by default. It seems to be defined at [this commit](https://github.com/YUKAI/konashi-ios-sdk/commit/63b63f457375287b4a74f26fcf4fce8f5fcd831a).